### PR TITLE
Change `node` and `feature` tests to functions that return promises.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ server.register([{
       // which tells the API to reply with the failure.
       node:[
         // TEST 1: validate the version of this codebase matches release for this ENV
-        new Promise((resolve, reject) => {
+        () => new Promise((resolve, reject) => {
           // check the release version against current codebase.
           // At deploy time, we update memcache with the release version for this env
           // using a deploy script (stored under 'app_version_'+env)
@@ -136,7 +136,7 @@ server.register([{
         })
       ],
       features:[
-        new Promise((resolve, reject) => {
+        () => new Promise((resolve, reject) => {
           // let's say we have a content directory that we use a tool like chef to
           // dump onto the running node from a github repo
           // this is a seperate dependency from the node

--- a/demo.js
+++ b/demo.js
@@ -32,14 +32,14 @@ server.register([{
       // is configured badly or has some other reason it
       // should be pulled out of rotation
       node: [
-        new Promise((resolve, reject) => {
+        () => new Promise((resolve, reject) => {
           // todo: test git commit hash / checksum against memcached manifest
           // to see if this node is in compliance with the release version
           resolve('code checksum matches manifest')
         })
       ],
       features: [
-        new Promise((resolve, reject) => {
+        () => new Promise((resolve, reject) => {
           // TODO: query a status report of a cron smoke test or
           // query memcached/redis, etc for logs of failures within a given timeframe
           // if we hit a threshold, return cb(true, message), which will throw this

--- a/lib/buildStatus.js
+++ b/lib/buildStatus.js
@@ -41,14 +41,14 @@ module.exports = function(opt) {
             // Node Tests (can result in FATAL)
             // if any one of our node tests fail, this node is bad
             // and should immediately be removed from rotation
-            Promise.all(opt.test.node)
+            Promise.all(opt.test.node.map(test => test()))
                 .then(data => responseJSON.service.status.message.push(data))
                 .catch(err => { 
                     statusCode = 500
                     responseJSON.service.status.state = opt.state.bad
                 }),
             // Feature Tests (can result in WARN)
-            Promise.all(opt.test.features)
+            Promise.all(opt.test.features.map(test => test()))
                 .then(data => responseJSON.service.status.message.push(data))
                 .catch(err => { 
                     responseJSON.service.status.state = opt.state.warn

--- a/lib/buildStatus.js
+++ b/lib/buildStatus.js
@@ -43,14 +43,16 @@ module.exports = function(opt) {
             // and should immediately be removed from rotation
             Promise.all(opt.test.node.map(test => test()))
                 .then(data => responseJSON.service.status.message.push(data))
-                .catch(err => { 
+                .catch(err => {
+                    responseJSON.service.status.message.push([err.message])
                     statusCode = 500
                     responseJSON.service.status.state = opt.state.bad
                 }),
             // Feature Tests (can result in WARN)
             Promise.all(opt.test.features.map(test => test()))
                 .then(data => responseJSON.service.status.message.push(data))
-                .catch(err => { 
+                .catch(err => {
+                    responseJSON.service.status.message.push([err.message])
                     responseJSON.service.status.state = opt.state.warn
                 })
         ]).then(function(data) {
@@ -75,7 +77,7 @@ module.exports = function(opt) {
             if (!verbose) {
                 return h.response(body).code(statusCode).type(type).etag(etag)
             }
-            
+
             let usageData = opt.usage ? systemStats.getUsage(request) : {}
             responseJSON = _.merge(responseJSON, {
                 service: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,12 +5,16 @@ module.exports = {
     id: 'git',
     lang: 'en',
     test: {
-        node: [function (cb) {
-            cb(false, 'no node tests have been defined')
-        }],
-        features: [function (cb) {
-            cb(false, 'no feature tests have been defined')
-        }]
+        node: [
+            function () {
+                return Promise.resolve('no node tests have been defined')
+            }
+        ],
+        features: [
+            function () {
+                return Promise.resolve('no feature tests have been defined')
+            }
+        ]
     },
     defaultContentType: 'text/plain',
     name: 'my_service',

--- a/test/fatal.basic.js
+++ b/test/fatal.basic.js
@@ -18,11 +18,15 @@ describe('Hapi-and-Healthy plugin: ' + setName, function() {
 
     const testPluginConfig = _.cloneDeep(pluginConfig)
     testPluginConfig.options.test.node = [
-        function(cb){
-            return cb(true, 'memcache is dead')
+        function () {
+            return new Promise(function (resolve, reject) {
+                reject(new Error('memcache is dead'))
+            })
         },
-        function(cb){
-            return cb(null, 'checksum good')
+        function () {
+            return new Promise(function (resolve, reject) {
+                resolve('checksum good')
+            })
         }
     ]
 

--- a/test/fatal.noUsage.js
+++ b/test/fatal.noUsage.js
@@ -18,11 +18,15 @@ describe('Hapi-and-Healthy plugin: ' + setName, function () {
 
     var testPluginConfig = _.cloneDeep(pluginConfig)
     testPluginConfig.options.test.node = [
-        function (cb) {
-            return cb(true, 'memcache is dead')
+        function () {
+            return new Promise(function (resolve, reject) {
+                reject(new Error('memcache is dead'))
+            })
         },
-        function (cb) {
-            return cb(null, 'checksum good')
+        function () {
+            return new Promise(function (resolve, reject) {
+                resolve('checksum good')
+            })
         }
     ]
     testPluginConfig.options.usage = false

--- a/test/lib/config.js
+++ b/test/lib/config.js
@@ -6,16 +6,30 @@ module.exports = {
         id: '1',
         name: pjson.name,
         test: {
-            node: [function (cb) {
-                return cb(null, 'memcache all good')
-            }, function (cb) {
-                return cb(null, 'checksum good')
-            }],
-            features: [function (cb) {
-                return cb(null, 'some feature is available')
-            }, function (cb) {
-                return cb(null, 'another feature is available')
-            }]
+            node: [
+                function () {
+                    return new Promise(function (resolve, reject) {
+                        resolve('memcache all good')
+                    })
+                },
+                function () {
+                    return new Promise(function (resolve, reject) {
+                        resolve('checksum good')
+                    })
+                },
+            ],
+            features: [
+                function () {
+                    return new Promise(function (resolve, reject) {
+                        resolve('some feature is available')
+                    })
+                },
+                function () {
+                    return new Promise(function (resolve, reject) {
+                        resolve('another feature is available')
+                    })
+                }
+            ]
         },
         state: {
             good: 'HEALTHY',

--- a/test/warn.basic.js
+++ b/test/warn.basic.js
@@ -19,11 +19,15 @@ describe('Hapi-and-Healthy plugin: ' + setName, function () {
 
     var testPluginConfig = _.cloneDeep(pluginConfig)
     testPluginConfig.options.test.features = [
-        function (cb) {
-            return cb(true, 'feature 1 is unavailable')
+        function () {
+            return new Promise(function (resolve, reject) {
+                reject(new Error('feature 1 is unavailable'))
+            })
         },
-        function (cb) {
-            return cb(null, 'feature 2 is available')
+        function () {
+            return new Promise(function (resolve, reject) {
+                resolve('feature 2 is available')
+            })
         }
     ]
     var code = 200

--- a/test/warn.noUsage.js
+++ b/test/warn.noUsage.js
@@ -19,11 +19,15 @@ describe('Hapi-and-Healthy plugin: ' + setName, function () {
 
     var testPluginConfig = _.cloneDeep(pluginConfig)
     testPluginConfig.options.test.features = [
-        function (cb) {
-            return cb(true, 'feature 1 is unavailable')
+        function () {
+            return new Promise(function (resolve, reject) {
+                reject(new Error('feature 1 is unavailable'))
+            })
         },
-        function (cb) {
-            return cb(null, 'feature 2 is available')
+        function () {
+            return new Promise(function (resolve, reject) {
+                resolve('feature 2 is available')
+            })
         }
     ]
     testPluginConfig.options.usage = false


### PR DESCRIPTION
This fixes #27.

These changes are not backwards-compatible and actually crash applications that use the current interface (passing in `node` and `feature` tests as arrays of promises). So, if you decide to accept this PR, you might want to release a new major version.