### PR TITLE
Move lodash from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
     "gulp-lab": "2.0.0",
     "gulp-supervisor": "0.1.2",
     "gulp-webserver": "0.9.1",
-    "lodash": "4.17.15",
     "open": "6.4.0",
     "snyk": "^1.217.3"
   },
   "dependencies": {
     "humanize-duration": "3.20.1",
+    "lodash": "4.17.15",
     "pretty-bytes": "5.3.0"
   },
   "snyk": true


### PR DESCRIPTION
lodash is referenced [there](https://github.com/atomantic/hapi-and-healthy/blob/83b41fd32c6c2d58553fc7a468c06e8b77d2c211/index.js#L3) so it belongs in dependencies not devDependencies.

(Code currently fails in production if lodash does not happen to be depended upon by some other package).