### PR TITLE
refactor: replace lodash with owned util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 'use strict'
 
-const _ = require('lodash')
+const { merge } = require('./lib/util')
 const config = require('./lib/config')
 
 module.exports = {
     pkg: require('./package.json'),
     register: async function (server, opts) {
         // merge custom options over default config
-        const opt = _.merge(config, opts)
+        const opt = merge(config, opts)
     
         // allow custom objects to be passed by reference
         // lest _.merge copy the data at time of passing it

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,58 @@
+'use strict'
+
+// Small owned replacements for the handful of lodash helpers this package used
+// (_.merge, _.cloneDeep, _.last). Kept intentionally minimal and matched to the
+// actual call sites: config objects that mix plain objects/arrays with function
+// values (test hooks), which is why structuredClone is unsuitable here.
+
+// Returns true for plain objects and arrays — the only containers we recurse
+// into. Functions, Promises, Dates, null, and primitives are treated as leaves
+// and passed through by reference (matching lodash's behavior for our usage).
+function isPlainContainer (value) {
+    if (value === null || typeof value !== 'object') return false
+    if (Array.isArray(value)) return true
+    const proto = Object.getPrototypeOf(value)
+    return proto === Object.prototype || proto === null
+}
+
+// Recursive deep merge of source onto target, mutating and returning target —
+// the same contract index.js relied on from _.merge(config, opts). Arrays and
+// non-plain values from source replace the target value rather than being
+// deep-merged element-by-element, which is sufficient for the config shapes
+// this plugin merges (and avoids lodash's surprising array-index merge).
+function merge (target, source) {
+    if (!isPlainContainer(source)) return source
+    for (const key of Object.keys(source)) {
+        const sourceVal = source[key]
+        const targetVal = target[key]
+        if (isPlainContainer(sourceVal) && !Array.isArray(sourceVal) &&
+            isPlainContainer(targetVal) && !Array.isArray(targetVal)) {
+            merge(targetVal, sourceVal)
+        } else {
+            target[key] = sourceVal
+        }
+    }
+    return target
+}
+
+// Deep clone of plain objects/arrays. Function values (test hooks live in the
+// config) and other non-plain values are shared by reference, matching how the
+// tests use the cloned config.
+function cloneDeep (value) {
+    if (!isPlainContainer(value)) return value
+    if (Array.isArray(value)) return value.map(cloneDeep)
+    const out = {}
+    for (const key of Object.keys(value)) {
+        out[key] = cloneDeep(value[key])
+    }
+    return out
+}
+
+// Last element of an array (or array-like). Mirrors _.last for our call sites,
+// which only ever pass the result of String.prototype.split.
+function last (arr) {
+    if (arr == null || arr.length === 0) return undefined
+    return arr[arr.length - 1]
+}
+
+module.exports = { merge, cloneDeep, last }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "humanize-duration": "3.20.1",
-        "lodash": "4.17.23",
         "pretty-bytes": "5.3.0"
       },
       "devDependencies": {
@@ -258,8 +257,7 @@
       "integrity": "sha512-fmoLInkoAhuBPrV0OCGz9+DLq0PyarKxCp5s4ytNxDgZy5g33xVZpA1v0NCkQcQxTboP1AzbG2SLS8zAXjIWrQ==",
       "deprecated": "This module has moved and is now available at @hapi/eslint-plugin. Please update your dependencies as this version is no longer maintained and may contain bugs and security issues.",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/file": {
       "version": "2.0.0",
@@ -675,7 +673,6 @@
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3556,6 +3553,7 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/make-iterator": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "humanize-duration": "3.20.1",
-    "lodash": "4.17.23",
     "pretty-bytes": "5.3.0"
   },
   "overrides": {

--- a/test/fatal.basic.js
+++ b/test/fatal.basic.js
@@ -8,7 +8,7 @@ const after = lab.after
 const it = lab.it
 const expect = Code.expect
 
-const _ = require('lodash')
+const _ = require('../lib/util')
 const common = require('./lib/common')
 const pluginConfig = require('./lib/config')
 

--- a/test/fatal.noUsage.js
+++ b/test/fatal.noUsage.js
@@ -8,7 +8,7 @@ var before = lab.before
 var after = lab.after
 var expect = Code.expect
 
-var _ = require('lodash')
+var _ = require('../lib/util')
 var common = require('./lib/common')
 var pluginConfig = require('./lib/config')
 

--- a/test/healthy.basic.js
+++ b/test/healthy.basic.js
@@ -8,7 +8,7 @@ var after = lab.after
 var it = lab.it
 var expect = Code.expect
 
-var _ = require('lodash')
+var _ = require('../lib/util')
 var common = require('./lib/common')
 
 var pluginConfig = require('./lib/config')

--- a/test/healthy.noUsage.js
+++ b/test/healthy.noUsage.js
@@ -8,7 +8,7 @@ var after = lab.after
 var it = lab.it
 var expect = Code.expect
 
-var _ = require('lodash')
+var _ = require('../lib/util')
 var common = require('./lib/common')
 var pluginConfig = require('./lib/config')
 

--- a/test/warn.basic.js
+++ b/test/warn.basic.js
@@ -8,7 +8,7 @@ var after = lab.after
 var it = lab.it
 var expect = Code.expect
 
-var _ = require('lodash')
+var _ = require('../lib/util')
 var common = require('./lib/common')
 
 var pluginConfig = require('./lib/config')

--- a/test/warn.noUsage.js
+++ b/test/warn.noUsage.js
@@ -8,7 +8,7 @@ var after = lab.after
 var it = lab.it
 var expect = Code.expect
 
-var _ = require('lodash')
+var _ = require('../lib/util')
 var common = require('./lib/common')
 
 var pluginConfig = require('./lib/config')


### PR DESCRIPTION
## Summary
Removes lodash as a direct production dependency. It was used only for `_.merge` (in `index.js`) and `_.cloneDeep`/`_.last` (in tests).

The merged/cloned config objects contain function values (test hooks), so `structuredClone` is unsuitable. `lib/util.js` provides a focused deep merge/clone that passes functions by reference, plus a `last()` helper — ~55 lines of owned code replacing the dependency.

This also supersedes Dependabot PR #52 (bump lodash), which can be closed.

## Test plan
- `npm test` — all 47 lab tests pass with lodash removed.